### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF by restricting URL schemes in HTTP sources

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-02-25: [High] Unvalidated URL schemes in downloaders enable SSRF/LFI (e.g. file://).

--- a/bumpkin/sources/basichttp/__init__.py
+++ b/bumpkin/sources/basichttp/__init__.py
@@ -15,6 +15,12 @@ class BasicHTTPSource(BaseSource):
         user_agent="curl/7.83.1",
         **kwargs,
     ):
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"Invalid URL scheme: {parsed.scheme}")
+
         self.url = url
         self.user_agent = user_agent
         self.rehash_if_same_url = rehash_if_same_url

--- a/bumpkin/sources/basichttpjsonvendor/__init__.py
+++ b/bumpkin/sources/basichttpjsonvendor/__init__.py
@@ -15,6 +15,12 @@ class BasicHTTPJSONVendorSource(BaseSource):
         user_agent="curl/7.83.1",
         **kwargs,
     ):
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"Invalid URL scheme: {parsed.scheme}")
+
         self.url = url
         self.user_agent = user_agent
         self.rehash_if_same_url = rehash_if_same_url

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -2,17 +2,21 @@ import pytest
 from bumpkin.sources.basichttp import BasicHTTPSource
 from bumpkin.sources.basichttpjsonvendor import BasicHTTPJSONVendorSource
 
+
 def test_basic_http_source_ssrf_protection():
     with pytest.raises(ValueError, match="Invalid URL scheme"):
         BasicHTTPSource(url="file:///etc/passwd")
+
 
 def test_basic_http_json_vendor_source_ssrf_protection():
     with pytest.raises(ValueError, match="Invalid URL scheme"):
         BasicHTTPJSONVendorSource(url="file:///etc/passwd")
 
+
 def test_basic_http_source_ftp_protection():
     with pytest.raises(ValueError, match="Invalid URL scheme"):
         BasicHTTPSource(url="ftp://example.com/file")
+
 
 def test_basic_http_source_valid_schemes():
     # Should not raise

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,20 @@
+import pytest
+from bumpkin.sources.basichttp import BasicHTTPSource
+from bumpkin.sources.basichttpjsonvendor import BasicHTTPJSONVendorSource
+
+def test_basic_http_source_ssrf_protection():
+    with pytest.raises(ValueError, match="Invalid URL scheme"):
+        BasicHTTPSource(url="file:///etc/passwd")
+
+def test_basic_http_json_vendor_source_ssrf_protection():
+    with pytest.raises(ValueError, match="Invalid URL scheme"):
+        BasicHTTPJSONVendorSource(url="file:///etc/passwd")
+
+def test_basic_http_source_ftp_protection():
+    with pytest.raises(ValueError, match="Invalid URL scheme"):
+        BasicHTTPSource(url="ftp://example.com/file")
+
+def test_basic_http_source_valid_schemes():
+    # Should not raise
+    BasicHTTPSource(url="http://example.com/file")
+    BasicHTTPSource(url="https://example.com/file")


### PR DESCRIPTION
## Vulnerability
**Class:** Server-Side Request Forgery (SSRF) / Local File Inclusion (LFI)
**Severity:** High
**Component:** `bumpkin.sources.basichttp.BasicHTTPSource`, `bumpkin.sources.basichttpjsonvendor.BasicHTTPJSONVendorSource`

The `BasicHTTPSource` and `BasicHTTPJSONVendorSource` classes used `urllib.request.urlopen` directly on user-provided URLs. By default, `urllib` supports the `file://` scheme, allowing a malicious actor to read local files on the system running `bumpkin` if they can control the input URL (e.g., via a crafted `bumpkin.json`).

## Impact
An attacker could read sensitive local files (e.g., `/etc/passwd`, environment variables, source code) by supplying a `file://` URL in the bumpkin configuration.

## Fix
The `__init__` methods of `BasicHTTPSource` and `BasicHTTPJSONVendorSource` now validate that the URL scheme is either `http` or `https` using `urllib.parse.urlparse`. If any other scheme is detected, a `ValueError` is raised.

## Verification
- Added `tests/test_security.py` which attempts to instantiate sources with `file://` and `ftp://` URLs.
- Verified that `ValueError` is raised for invalid schemes.
- Verified that `http://` and `https://` URLs are accepted.
- Ran `mise run test` to ensure all tests pass.

## Assumptions
- The tool is intended to fetch resources only via HTTP/HTTPS.
- Users do not rely on `file://` URLs for local testing with these specific source types (if they do, they should use a file path directly or a different source type, though none exists currently for local files).

## Alternatives Not Chosen
- implementing a custom `OpenerDirector` to remove file handlers (more complex).
- Checking scheme inside `reduce` method (checking at initialization is safer and fails faster).

## How To Pivot
If local file access is a desired feature, we should create a separate `BasicFileSource` class and explicitly allow it, rather than implicitly allowing it in `BasicHTTPSource`.

## Next Knobs
- `bumpkin/sources/basichttp/__init__.py`: Modify the allowed schemes tuple if other protocols (e.g. `ftp`) are needed.


---
*PR created automatically by Jules for task [16874278442539584122](https://jules.google.com/task/16874278442539584122) started by @lucasew*