### PR TITLE
📝 Docs: Add comprehensive docstrings to bumpkin/sources module

### DIFF
--- a/bumpkin/sources/__init__.py
+++ b/bumpkin/sources/__init__.py
@@ -18,6 +18,12 @@ default_sources = [
 
 
 def setup_source(source):
+    """
+    Registers a new source class into the global sources dictionary.
+
+    Validates that the provided class subclasses `BaseSource` and that its
+    `SOURCE_KEY` (e.g. '_type' in JSON) is unique.
+    """
     assert issubclass(source, BaseSource), f"class {source} is not based on BaseSource"
     assert sources.get(source.SOURCE_KEY) is None, (
         f"class {source} has the samekey ({source.SOURCE_KEY}) as {sources.get(source.SOURCE_KEY)}"
@@ -30,6 +36,14 @@ for default_source in default_sources:
 
 
 def eval_node(declaration, previous_data=dict()):
+    """
+    Processes a single node payload, resolving its intended source type and dispatching
+    it to that source's `reduce` method.
+
+    Injects `_bpk_last_update` with the current timestamp into the result upon success.
+    Captures unhandled exceptions and HTTP errors gracefully, returning the previous
+    state rather than failing the entire evaluation tree.
+    """
     from time import time
     from urllib import request
 
@@ -88,6 +102,12 @@ def get_subcommands(subparser):
 
 
 def list_nodes(declaration=None, previous_data=None, _key=[]):
+    """
+    Flattens the deeply nested JSON declaration structure into a dot-notated dictionary.
+
+    Returns a mapping of dot-separated paths (e.g. "x86_64-linux.stable") to their
+    last updated timestamp. This allows determining evaluation ordering based on age.
+    """
     if type(declaration) is not dict:
         return {}
     if declaration.get("_type") is None:
@@ -116,6 +136,13 @@ def list_nodes(declaration=None, previous_data=None, _key=[]):
 
 
 def eval_nodes_recursively(declaration=None, previous_data=None):
+    """
+    Walks the nested declaration tree structure, evaluating each valid node.
+
+    Recursively delegates to `eval_node` if a dictionary includes a `_type` field,
+    otherwise continues traversing child nodes. Rejects lists because structural
+    shifts cannot be mapped deterministically.
+    """
     if isinstance(declaration, dict):
         if declaration.get("_type"):
             return eval_node(
@@ -152,6 +179,13 @@ def eval_nodes_key(declaration=None, previous_data=None, key=[]):
 
 
 def eval_nodes(declaration=None, previous_data=None, keys=[]):
+    """
+    Coordinates the top-level evaluation of the node graph.
+
+    Supports partial evaluations by specifying `keys` to bump only targeted nodes.
+    Discovers all nodes, sorts them by their previous `_bpk_last_update` timestamp
+    (prioritizing older nodes), and serially updates each requested branch.
+    """
     listed_nodes = list_nodes(declaration, previous_data)
     _keys = []
     for key in keys:

--- a/bumpkin/sources/base.py
+++ b/bumpkin/sources/base.py
@@ -1,13 +1,35 @@
 class BaseSource:
+    """
+    Abstract base class for all bumpkin sources.
+
+    A source acts as a reducer for a specific resource (like a file via HTTP or a GitHub release).
+    It takes the configuration parameters and exposes a `reduce` method to compute the new state,
+    comparing it against the previous state to avoid unnecessary work (e.g. refetching).
+    """
+
     SOURCE_KEY = "_base"
 
     def __init__(self, **kwargs):
+        """
+        Initializes the source with declarative parameters from the JSON manifest.
+        """
         self.kwargs = kwargs
 
     def reduce(self, **kwargs):
+        """
+        Evaluates the resource and computes the new state.
+
+        Takes the previous state data as keyword arguments. Implementations should return
+        a dictionary containing the updated state, including any new URLs or computed hashes.
+        """
         raise Exception("Unimplemented")
 
     @classmethod
     def argparse(cls, parser):
+        """
+        Populates the CLI subparser with arguments specific to this source.
+
+        Allows the source to be invoked and tested directly via the command line.
+        """
         raise Exception("Unimplemented")
         return parser

--- a/bumpkin/sources/basicgithub/__init__.py
+++ b/bumpkin/sources/basicgithub/__init__.py
@@ -8,6 +8,16 @@ PREFIXES = ["", "/heads", "/tags"]
 
 
 class BasicGitHubSource(BaseSource):
+    """
+    Source implementation that tracks a specific GitHub repository reference
+    (e.g., branch or tag) and downloads an archive of the code.
+
+    This source discovers the latest commit hash for the reference using the
+    GitHub matching-refs API, ensuring updates trigger when the ref points to a
+    new commit. If a matching ref is not explicitly provided, it will fallback
+    to the repository's default branch.
+    """
+
     SOURCE_KEY = "basicgithub"
 
     def __init__(
@@ -20,6 +30,9 @@ class BasicGitHubSource(BaseSource):
         rehash_if_same_url=False,
         **kwargs,
     ):
+        """
+        Initializes the GitHub source config.
+        """
         self.owner = owner
         self.repo = repo
         self.ref = ref
@@ -34,6 +47,9 @@ class BasicGitHubSource(BaseSource):
         ], "file type must be either zip or tar.gz"
 
     def _get_default_branch(self):
+        """
+        Queries the GitHub API to retrieve the default branch name of the repository.
+        """
         from json import load
         from urllib import request
 
@@ -45,6 +61,14 @@ class BasicGitHubSource(BaseSource):
         return f"heads/{branch}"
 
     def reduce(self, **kwargs):
+        """
+        Evaluates the GitHub repository's ref to find the latest commit hash.
+
+        If the final archive URL matches the previously processed URL (unless
+        `rehash_if_same_url` is True), it skips downloading and hashing to
+        optimize performance. Returns updated state containing the matched commit
+        hash, file type, final download URL, and sha256.
+        """
         from json import load
         from urllib import request
 

--- a/bumpkin/sources/basichttp/__init__.py
+++ b/bumpkin/sources/basichttp/__init__.py
@@ -6,6 +6,14 @@ logger = logging.getLogger(__name__)
 
 
 class BasicHTTPSource(BaseSource):
+    """
+    Standard source implementation for resolving and hashing files served over HTTP/HTTPS.
+
+    This source follows HTTP redirects to find the ultimate download location.
+    If the resolved final URL matches the cached URL from the previous state,
+    it skips the potentially expensive download/hashing step unless explicitly told otherwise.
+    """
+
     SOURCE_KEY = "basichttp"
 
     def __init__(
@@ -15,11 +23,20 @@ class BasicHTTPSource(BaseSource):
         user_agent="curl/7.83.1",
         **kwargs,
     ):
+        """
+        Initializes the HTTP source with the target URL.
+        """
         self.url = url
         self.user_agent = user_agent
         self.rehash_if_same_url = rehash_if_same_url
 
     def reduce(self, **kwargs):
+        """
+        Executes the HTTP GET request and calculates the sha256 checksum of the response.
+
+        Only streams and hashes the response body if the resolved (post-redirect) URL differs
+        from the previous final URL, reducing bandwidth and processing time.
+        """
         from urllib import request
 
         ret = kwargs

--- a/bumpkin/sources/basichttpjsonvendor/__init__.py
+++ b/bumpkin/sources/basichttpjsonvendor/__init__.py
@@ -6,6 +6,12 @@ logger = logging.getLogger(__name__)
 
 
 class BasicHTTPJSONVendorSource(BaseSource):
+    """
+    HTTP source variant designed specifically to consume JSON endpoints directly.
+    Instead of downloading a file to compute a hash, this source parses the
+    response body as JSON and incorporates those keys into the bumped state.
+    """
+
     SOURCE_KEY = "basichttpjsonvendor"
 
     def __init__(
@@ -15,11 +21,20 @@ class BasicHTTPJSONVendorSource(BaseSource):
         user_agent="curl/7.83.1",
         **kwargs,
     ):
+        """
+        Initializes the HTTP JSON vendor source.
+        """
         self.url = url
         self.user_agent = user_agent
         self.rehash_if_same_url = rehash_if_same_url
 
     def reduce(self, **kwargs):
+        """
+        Fetches the JSON payload from the configured URL.
+
+        It overwrites the entire node state with the parsed JSON dictionary
+        and appends the `final_url` after any redirects.
+        """
         from json import load
         from urllib import request
 


### PR DESCRIPTION
## Assumptions
- The main entrypoint for sources is the `reduce` method which takes and returns a dictionary payload representing state.
- `_bpk_last_update` injection is a core feature of the evaluator (`eval_node`), rather than the source class itself.
- Returning `previous_data` upon failure prevents an entire node graph evaluation from crashing.

## Alternatives Not Chosen
- Adding inline `#` comments: Standard python docstrings (`"""`) are more robust and can be aggregated by IDEs or Sphinx/mkdocs later.
- Documenting other modules: Opted to strictly scope this PR to `bumpkin/sources` to maintain a single cohesive area of work per PR.

## How To Pivot
- If standard Sphinx/Google style is required instead, I can script a quick rewrite using `sed` or Python's `ast` module to adapt the style across the modified files.
- If less verbose docstrings are preferred, they can be pruned to single-line summaries.

## Next Knobs
- `bumpkin/sources/__init__.py`: To adjust the explanation of `list_nodes` sorting behavior.
- `bumpkin/cli.py`: The next logical file that would heavily benefit from similar comprehensive docstrings detailing the command line argument semantics.

---
*PR created automatically by Jules for task [6401668413796185174](https://jules.google.com/task/6401668413796185174) started by @lucasew*