### PR TITLE
🛠️ Refactor: Remove empty catch blocks and replace magic numbers

### DIFF
--- a/bumpkin/sources/__init__.py
+++ b/bumpkin/sources/__init__.py
@@ -106,12 +106,8 @@ def list_nodes(declaration=None, previous_data=None, _key=[]):
     else:
         ret = {}
         ret[".".join(_key)] = 1 if previous_data is not None else 0
-        try:
+        if isinstance(previous_data, dict) and "_bpk_last_update" in previous_data:
             ret[".".join(_key)] = previous_data["_bpk_last_update"]
-        except KeyError:
-            pass
-        except TypeError:
-            pass
         return ret
 
 

--- a/bumpkin/sources/basicgithub/__init__.py
+++ b/bumpkin/sources/basicgithub/__init__.py
@@ -5,6 +5,7 @@ from ..base import BaseSource
 logger = logging.getLogger(__name__)
 
 PREFIXES = ["", "/heads", "/tags"]
+CHUNK_SIZE = 16 * 1024
 
 
 class BasicGitHubSource(BaseSource):
@@ -118,7 +119,7 @@ class BasicGitHubSource(BaseSource):
 
             hasher = hashlib.sha256()
             while True:
-                buf = res.read(16 * 1024)
+                buf = res.read(CHUNK_SIZE)
                 if not buf:
                     break
                 hasher.update(buf)

--- a/bumpkin/sources/basichttp/__init__.py
+++ b/bumpkin/sources/basichttp/__init__.py
@@ -4,6 +4,8 @@ from ..base import BaseSource
 
 logger = logging.getLogger(__name__)
 
+CHUNK_SIZE = 16 * 1024
+
 
 class BasicHTTPSource(BaseSource):
     SOURCE_KEY = "basichttp"
@@ -41,7 +43,7 @@ class BasicHTTPSource(BaseSource):
 
             hasher = hashlib.sha256()
             while True:
-                buf = res.read(16 * 1024)
+                buf = res.read(CHUNK_SIZE)
                 if not buf:
                     break
                 hasher.update(buf)


### PR DESCRIPTION
🛠️ Refactor: Remove empty catch blocks and replace magic numbers

This pull request implements key code quality refactorings as outlined in our guidelines, specifically addressing empty catch blocks (a known retroactive violation) and replacing magic numbers to reduce cognitive load.

### Assumptions
- The change from using `try...except` block logic to explicit `isinstance(..., dict)` checks maintains correct functionality as verified by our evaluation and unit testing.
- Replacing the magic number `16 * 1024` with `CHUNK_SIZE` directly implements Robert C. Martin's clean code principles without altering block sizes or stream behaviors.
- Our CI execution environment (`mise run ci`/`mise run test`) captures the core dependencies of the application correctly.

### Alternatives Not Chosen
- We considered flattening the sparse directories `bumpkin/sources/basichttp`, `bumpkin/sources/basicgithub`, and `bumpkin/sources/basichttpjsonvendor` into `.py` files. However, this was deemed an unsafe positional change without first fully validating `importlib` dynamics inside `bumpkin.sources.__init__.py` module. It was separated out to focus atomic changes solely on extraction-level problems.
- Keeping the exception-based pattern in `list_nodes` and just adding a logging line to the `catch` blocks. We explicitly chose the "Replace Exception with Test" approach from Martin Fowler to structurally eliminate the negative pattern rather than patching it.

### How To Pivot
If these changes introduce issues in the source evaluation streams, the easiest path to pivot is simply to roll back `CHUNK_SIZE` variable additions, and revert the conditional statement inside `list_nodes` to the former `try...except KeyError, TypeError` behavior.

### Next Knobs
1. Investigate the `eval_nodes` system to see if we can use centralized error logging handling instead of `print` or `logger.info(e)` on generic generic Exceptions as well.
2. We could explore refactoring out the repeated file hash generation `while True` read loops inside both GitHub and HTTP sources into a shared base method in `BaseSource` to follow the DRY principle.

---
*PR created automatically by Jules for task [11262793264670951381](https://jules.google.com/task/11262793264670951381) started by @lucasew*